### PR TITLE
Rename 'sign in with google' variable (server-side)

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -33,17 +33,20 @@ except KeyError:
     ADMIN = []
 
 JWT_EXPIRE_TIME = 3600
+
+# SS_SUPPORT_GOOGLE_OAUTH2 is for server-side apps sign in with google
+# Detail : https://developers.google.com/identity/sign-in/web/server-side-flow
 try:
-    SUPPORT_GOOGLE_OAUTH2 = os.environ['SUPPORT_GOOGLE_OAUTH2'].lower(
+    SS_SUPPORT_GOOGLE_OAUTH2 = os.environ['SS_SUPPORT_GOOGLE_OAUTH2'].lower(
     ) == "true"
 except KeyError:
-    SUPPORT_GOOGLE_OAUTH2 = False
+    SS_SUPPORT_GOOGLE_OAUTH2 = False
 
 GOOGLE_OAUTH2_CLIENT_ID = None
 GOOGLE_OAUTH2_CLIENT_SECRET = None
 GOOGLE_OAUTH2_REDIRECT_URI = None
 
-if SUPPORT_GOOGLE_OAUTH2:
+if SS_SUPPORT_GOOGLE_OAUTH2:
     GOOGLE_OAUTH2_CLIENT_ID = os.environ['GOOGLE_OAUTH2_CLIENT_ID']
     GOOGLE_OAUTH2_CLIENT_SECRET = os.environ['GOOGLE_OAUTH2_CLIENT_SECRET']
     GOOGLE_OAUTH2_REDIRECT_URI = os.environ['GOOGLE_OAUTH2_REDIRECT_URI']

--- a/src/web-server.py
+++ b/src/web-server.py
@@ -5,7 +5,7 @@ from announcements.review import ReviewService
 from auth.auth_service import AuthService
 from cache.announcements_cache import CacheManager
 from view import announcement_view, application_view, auth_view
-from utils.config import SUPPORT_GOOGLE_OAUTH2
+from utils.config import SS_SUPPORT_GOOGLE_OAUTH2
 app = falcon.API()
 auth_service = AuthService()
 acs = AnnouncementService()
@@ -82,8 +82,8 @@ app.add_route(
     '/user/info',
     auth_view.UserInfo()
 )
-
-if SUPPORT_GOOGLE_OAUTH2:
+# For server-side sign in ith google.
+if SS_SUPPORT_GOOGLE_OAUTH2:
     app.add_route(
         '/oauth2/google/login',
         auth_view.GoogleOauthLogin(auth_service=auth_service)


### PR DESCRIPTION
為了避免誤會，此API實作的Google Oauth2 是使用Server-side app的實作方式
https://developers.google.com/identity/sign-in/web/server-side-flow
故在命名都加上了SS
